### PR TITLE
Fixes #2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,17 @@
 GitPython==0.3.2.RC1
 async==0.6.1
 -e git+https://github.com/AaronO/dulwich.git@a1aa061e5b6c8d6acbe805f174205d2323231449#egg=dulwich-dev
-funky==0.0.1
+-e git+https://github.com/FriendCode/funky.git@e89cb2ce4374bf2069c7f669e52e046f63757241#egg=funky-dev
 gitdb==0.5.4
 gittle==0.1.1
 ipython==0.13.1
 logilab-astng==0.24.1
 logilab-common==0.59.0
-mercurial==2.4
--e git+ssh://git@friendco.de/opt/git/friendcode/mimer.git@6a5704dc307ec9c6f3feb5e3a60cd469b449d5eb#egg=mimer-dev
+mercurial
+-e git+https://github.com/FriendCode/mimer.git#egg=mimer-dev
 paramiko==1.10.0
 pycrypto==2.6
 pylint==0.26.0
 smmap==0.8.2
 wsgiref==0.1.2
+


### PR DESCRIPTION
added the correct github line for funky
removed mercurial 2.4 as its no longer on Pypi
fixed mimer link from private git to public github
