### PR TITLE
Fix undeclared var commit_sha in checkout()

### DIFF
--- a/gittle/gittle.py
+++ b/gittle/gittle.py
@@ -737,7 +737,7 @@ class Gittle(object):
         """Checkout a given ref or SHA
         """
         self.repo.refs.set_symbolic_ref('HEAD', ref)
-        commit_tree = self._commit_tree(commit_sha)
+        commit_tree = self._commit_tree(ref)
         # Rebuild index from the current tree
         return self._checkout_tree(commit_tree)
 


### PR DESCRIPTION
`commit_sha` wasn't declared anywhere in `repo.checkout()`. Change `commit_sha` to `ref` instead, which was a passed parameter anyway.
