### PR TITLE
Removes the dependency on the mimer library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,12 +39,10 @@ setup_kwargs = {
     # Non PyPI
     'dulwich',
     'funky',
-    'mimer',
     ],
     'dependency_links': [
         'https://github.com/AaronO/dulwich/tarball/eebb032b2b7b982d21d636ac50b6e45de58b208b#egg=dulwich-0.9.1-2',
         'https://github.com/FriendCode/funky/tarball/e89cb2ce4374bf2069c7f669e52e046f63757241#egg=funky-0.0.1',
-        'https://github.com/FriendCode/mimer/tarball/a812e5f631b9b5c969df5a2ea84b635490a96ced#egg=mimer-0.0.1',
     ],
 }
 


### PR DESCRIPTION
Uses functionality built-in to dulwich to determine whether a file is
treated as binary or text. This allows Gittle to behave closer to what
`git diff` actually produces.
