### PR TITLE
Changes deprecated revision_history to get_walker

### DIFF
--- a/gittle/gittle.py
+++ b/gittle/gittle.py
@@ -203,7 +203,8 @@ class Gittle(object):
         """
         ref = ref or 'HEAD'
         sha = self._commit_sha(ref)
-        return self.repo.revision_history(sha)
+        for entry in self.repo.get_walker(sha):
+            yield entry.commit
 
     def branch_walker(self, branch):
         branch = branch or self.DEFAULT_BRANCH


### PR DESCRIPTION
dulwich.repo.Repo.revision_history has been deprecated as of 0.8.1. It has since been completely removed from later versions.
