### PR TITLE
only ref is supported

### DIFF
--- a/gittle/gittle.py
+++ b/gittle/gittle.py
@@ -735,7 +735,7 @@ class Gittle(object):
         return self._checkout_tree(commit_tree)
 
     def checkout(self, ref):
-        """Checkout a given ref or SHA
+        """Checkout a given ref
         """
         self.repo.refs.set_symbolic_ref('HEAD', ref)
         commit_tree = self._commit_tree(ref)


### PR DESCRIPTION
   def set_symbolic_ref(self, name, other):
        """Make a ref point at another ref.

```
    :param name: Name of the ref to set
    :param other: Name of the ref to point at
    """
    self._check_refname(name)
    self._check_refname(other)
    filename = self.refpath(name)
    try:
        f = GitFile(filename, 'wb')
        try:
            f.write(SYMREF + other + '\n')
        except (IOError, OSError):
            f.abort()
            raise
    finally:
        f.close()
```

here is the checking

```
def _check_refname(self, name):
    """Ensure a refname is valid and lives in refs or is HEAD.

    HEAD is not a valid refname according to git-check-ref-format, but this
    class needs to be able to touch HEAD. Also, check_ref_format expects
    refnames without the leading 'refs/', but this class requires that
    so it cannot touch anything outside the refs dir (or HEAD).

    :param name: The name of the reference.
    :raises KeyError: if a refname is not HEAD or is otherwise not valid.
    """
    if name in ('HEAD', 'refs/stash'):
        return
    if not name.startswith('refs/') or not check_ref_format(name[5:]):
        raise RefFormatError(name)
```

Example:

```
----> 1 gitrepo.checkout(ref='2bf1af2cab4dba5aa9df5d8af83829722a35e9e1')

/home/woronicz/Envs/rel5/local/lib/python2.7/site-packages/gittle/gittle.pyc in checkout(self, ref)
    738         """Checkout a given ref or SHA
    739         """
--> 740         self.repo.refs.set_symbolic_ref('HEAD', ref)
    741         commit_tree = self._commit_tree(ref)
    742         # Rebuild index from the current tree

/home/woronicz/Envs/rel5/local/lib/python2.7/site-packages/dulwich/refs.pyc in set_symbolic_ref(self, name, other)
    538         """
    539         self._check_refname(name)
--> 540         self._check_refname(other)
    541         filename = self.refpath(name)
    542         try:

/home/woronicz/Envs/rel5/local/lib/python2.7/site-packages/dulwich/refs.pyc in _check_refname(self, name)
    168             return
    169         if not name.startswith('refs/') or not check_ref_format(name[5:]):
--> 170             raise RefFormatError(name)
    171 
    172     def read_ref(self, refname):

RefFormatError: 2bf1af2cab4dba5aa9df5d8af83829722a35e9e1
```
