### PR TITLE
Fix of refspec added to git config on add_remote

### DIFF
--- a/gittle/gittle.py
+++ b/gittle/gittle.py
@@ -1052,7 +1052,7 @@ class Gittle(object):
 
         # Add new entries for remote
         config.set(('remote', remote_name), 'url', remote_url)
-        config.set(('remote', remote_name), 'fetch', ":+refs/heads/*:refs/remotes/%s/*" % remote_name)
+        config.set(('remote', remote_name), 'fetch', "+refs/heads/*:refs/remotes/%s/*" % remote_name)
 
         # Write to disk
         config.write_to_path()


### PR DESCRIPTION
There is no need for leading ':' in refspec. It actually makes it incorrect, and brakes push and pull.