### PR TITLE
Is repo

### DIFF
--- a/gittle/gittle.py
+++ b/gittle/gittle.py
@@ -57,16 +57,6 @@ def bare_only(method):
     return f
 
 
-def is_repo(path):
-    """Returns True if path is a git repository, False if it is not"""
-    try:
-        repo = Gittle(path)
-    except NotGitRepository:
-        return False
-    else:
-        return True
-
-
 class Gittle(object):
     """All paths used in Gittle external methods must be paths relative to the git repository
     """
@@ -318,6 +308,16 @@ class Gittle(object):
     def init_bare(cls, *args, **kwargs):
         kwargs.setdefault('bare', True)
         return cls.init(*args, **kwargs)
+
+    @classmethod
+    def is_repo(cls, path):
+        """Returns True if path is a git repository, False if it is not"""
+        try:
+            repo = Gittle(path)
+        except NotGitRepository:
+            return False
+        else:
+            return True
 
     def get_client(self, origin_uri=None, **kwargs):
         # Get the remote URL

--- a/gittle/gittle.py
+++ b/gittle/gittle.py
@@ -16,6 +16,7 @@ from dulwich.index import build_index_from_tree, changes_from_tree
 from dulwich.objects import Tree, Blob
 from dulwich.server import update_server_info
 from dulwich.refs import SYMREF
+from dulwich.errors import NotGitRepository
 
 # Funky imports
 import funky
@@ -54,6 +55,16 @@ def bare_only(method):
         assert self.is_bare, "%s can not be called on a working repository" % method.func_name
         return method(self, *args, **kwargs)
     return f
+
+
+def is_repo(path):
+    """Returns True if path is a git repository, False if it is not"""
+    try:
+        repo = Gittle(path)
+    except NotGitRepository:
+        return False
+    else:
+        return True
 
 
 class Gittle(object):


### PR DESCRIPTION
Added a classmethod to Gittle which returns True if path is a repo, False if it is not. I've found this useful to make my code more readable for example:

instead of

```python
import sys
from gittle import Gittle
from dulwich.errors import NotGitRepository

try:
    repo = Gittle('/path')
except NotGitRepository:
    print("Not a git repository")
    sys.exit(-1)
```

I can write

```python
from gittle import Gittle

if not Gittle.is_repo('/path'):
    print("Not a git repository")
    sys.exit(-1)
```