### PR TITLE
fixed some error in Python3

### DIFF
--- a/gittle/auth.py
+++ b/gittle/auth.py
@@ -22,6 +22,8 @@ from .exceptions import InvalidRSAKey
 # Exports
 __all__ = ('GittleAuth',)
 
+if os.sys.version_info.major > 2 or (os.sys.version_info.major == 2 and os.sys.version_info.minor < 7):
+    basestring = str
 
 def get_pkey_file(pkey):
     if isinstance(pkey, basestring):

--- a/gittle/auth.py
+++ b/gittle/auth.py
@@ -2,7 +2,7 @@
 import os
 try:
     # Try importing the faster version
-    from cStringIO import StringIO
+    from io import StringIO
 except ImportError:
     # Fallback to pure python if not available
     from StringIO import StringIO

--- a/gittle/gittle.py
+++ b/gittle/gittle.py
@@ -29,6 +29,8 @@ from gittle import utils
 # Exports
 __all__ = ('Gittle',)
 
+if os.sys.version_info.major > 2 or (os.sys.version_info.major == 2 and os.sys.version_info.minor < 7):
+    basestring = str
 
 # Guarantee that a diretory exists
 def mkdir_safe(path):

--- a/gittle/gittle.py
+++ b/gittle/gittle.py
@@ -95,7 +95,7 @@ class Gittle(object):
     PATTERN_MODIFIED = (True, True)
 
     # Permissions
-    MODE_DIRECTORY = 040000  # Used to tell if a tree entry is a directory
+    MODE_DIRECTORY = 0o40000  # Used to tell if a tree entry is a directory
 
     # Tree depth
     MAX_TREE_DEPTH = 1000

--- a/gittle/utils/git.py
+++ b/gittle/utils/git.py
@@ -16,6 +16,8 @@ from dulwich.patch import is_binary
 # Funky imports
 from funky import first, true_only, rest, negate, transform
 
+if os.sys.version_info.major > 2 or (os.sys.version_info.major == 2 and os.sys.version_info.minor < 7):
+    basestring = str
 
 def is_readable(store):
     def fn(info):

--- a/gittle/utils/git.py
+++ b/gittle/utils/git.py
@@ -1,6 +1,11 @@
 # Python imports
 import os
-from StringIO import StringIO
+
+try:
+    from io import StringIO
+except ImportError:
+    from StringIO import StringIO
+
 from functools import partial
 
 # Dulwich imports

--- a/gittle/utils/urls.py
+++ b/gittle/utils/urls.py
@@ -1,5 +1,8 @@
 # Python imports
-from urlparse import urlparse
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
 # Local imports
 from funky import first_true


### PR DESCRIPTION
2 modules _`urlparse`_ and _`StringIO`_ import changed in Python 3.

`040000` in Python 2, changed to `0o40000` in Python 3

_`basestring`_ is not defined in Python 3, replaced with _`str`_