### PR TITLE
Upgrades setup for Py3 conversion and runs 2to3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ nosetests.xml
 
 # gvim
 .*.swp
+*.bak

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+clean:
+	rm -rf *.egg-info
+	rm -rf build
+	rm -rf dist
+
+tag-release:
+	sed -i "0,/version_string/c\version_string = '$(v)'" setup.py
+	git add setup.py && git commit -m "Automated version bump to $(v)" && git push
+	git tag -a release/$(v) -m "Automated release of $(v) via Makefile" && git push origin --tags
+
+package:
+	rm -rf build
+	python setup.py clean
+	python setup.py build sdist bdist_wheel
+
+distribute:
+	twine upload -s dist/gittle-$(v)*
+
+release:
+	$(MAKE) tag-release
+	$(MAKE) package
+	$(MAKE) distribute

--- a/examples/clone.py
+++ b/examples/clone.py
@@ -5,4 +5,4 @@ repo_url = 'git://github.com/AaronO/dulwich.git'
 
 repo = Gittle.clone(repo_url, repo_path)
 
-print(repo.tracked_files)
+print((repo.tracked_files))

--- a/examples/clone_bare.py
+++ b/examples/clone_bare.py
@@ -5,4 +5,4 @@ repo_url = 'git://github.com/AaronO/dulwich.git'
 
 repo = Gittle.clone_bare(repo_url, repo_path)
 
-print(repo.tracked_files)
+print((repo.tracked_files))

--- a/examples/commit.py
+++ b/examples/commit.py
@@ -31,6 +31,6 @@ repo.stage(fn)
 repo.commit(name=name, email=email, message=message)
 
 
-print('COMMIT_INFO =', repo.commit_info())
+print(('COMMIT_INFO =', repo.commit_info()))
 
-print('PATH =', path)
+print(('PATH =', path))

--- a/examples/complete.py
+++ b/examples/complete.py
@@ -12,10 +12,10 @@ path = '/tmp/gittle_bare'
 repo = Gittle.clone('git://github.com/FriendCode/gittle.git', path)
 
 # Information
-print "Branches :"
-print repo.branches
-print "Commits :"
-print repo.commit_count
+print("Branches :")
+print(repo.branches)
+print("Commits :")
+print(repo.commit_count)
 
 # Commiting
 fn = 'test.txt'
@@ -33,7 +33,7 @@ repo.stage(fn)
 repo.commit(name='Samy Pessé', email='samypesse@gmail.com', message="This is a commit")
 
 # Commit info
-print "Commit : ", repo.commit_info()
+print("Commit : ", repo.commit_info())
 
 # Auth for pushing
 repo.auth(pkey=open("private_key"))

--- a/examples/diff.py
+++ b/examples/diff.py
@@ -7,7 +7,7 @@ lastest = [
     for info in repo.commit_info()[1:3]
 ]
 
-print(repo.diff(*lastest, diff_type='classic'))
+print((repo.diff(*lastest, diff_type='classic')))
 
 print("""
 
@@ -16,4 +16,4 @@ Last Diff
 """)
 
 
-print(list(repo.diff('HEAD')))
+print((list(repo.diff('HEAD'))))

--- a/examples/paths.py
+++ b/examples/paths.py
@@ -13,10 +13,10 @@ BASE_DIR = '/Users/aaron/git/'
 absbase = partial(os.path.join, BASE_DIR)
 
 TRIES = 1
-PATHS = map(absbase, [
+PATHS = list(map(absbase, [
     'gittle/',
     'loadfire/',
-])
+]))
 
 
 def paths_exists(repo):
@@ -51,7 +51,7 @@ def test_repo(repo_path):
 def main():
     paths = PATHS * TRIES
     for path in paths:
-        print('Testing : %s' % path)
+        print(('Testing : %s' % path))
         test_repo(path)
 
 

--- a/examples/status.py
+++ b/examples/status.py
@@ -15,8 +15,8 @@ def print_files(group_name, paths):
     if not paths:
         return
     sorted_paths = sorted(paths)
-    print("\n%s :" % group_name)
-    print('\n'.join(sorted_paths))
+    print(("\n%s :" % group_name))
+    print(('\n'.join(sorted_paths)))
 
 #print_files('Changes not staged for commit', g.modified_unstaged_files)
 #print_files('Changes staged for commit', g.modified_staged_files)

--- a/examples/versions.py
+++ b/examples/versions.py
@@ -3,4 +3,4 @@ from gittle import Gittle
 repo = Gittle('.')
 versions = repo.get_file_versions('gittle/gittle.py')
 
-print("Found %d versions out of a total of %d commits" % (len(versions), repo.commit_count()))
+print(("Found %d versions out of a total of %d commits" % (len(versions), repo.commit_count())))

--- a/gittle/auth.py
+++ b/gittle/auth.py
@@ -11,7 +11,7 @@ try:
     from io import StringIO
 except ImportError:
     # Fallback to pure python if not available
-    from StringIO import StringIO
+    from io import StringIO
 
 
 # Paramiko imports
@@ -29,10 +29,10 @@ from .exceptions import InvalidRSAKey
 __all__ = ('GittleAuth',)
 
 if os.sys.version_info.major > 2 or (os.sys.version_info.major == 2 and os.sys.version_info.minor < 7):
-    basestring = str
+    str = str
 
 def get_pkey_file(pkey):
-    if isinstance(pkey, basestring):
+    if isinstance(pkey, str):
         if os.path.exists(pkey):
             pkey_file = open(pkey)
         else:

--- a/gittle/server.py
+++ b/gittle/server.py
@@ -41,8 +41,8 @@ class SubFileSystemBackend(FileSystemBackend):
         stripped_path = path.strip('/')
         full_path = self.rewrite_path(stripped_path)
 
-        print('opening %s' % path)
-        print('full path = %s' % full_path)
+        print(('opening %s' % path))
+        print(('full path = %s' % full_path))
 
         return super(SubFileSystemBackend, self).open_repository(full_path)
 

--- a/gittle/utils/git.py
+++ b/gittle/utils/git.py
@@ -11,7 +11,7 @@ import os
 try:
     from io import StringIO
 except ImportError:
-    from StringIO import StringIO
+    from io import StringIO
 
 from functools import partial
 
@@ -24,7 +24,7 @@ from dulwich.patch import is_binary
 from funky import first, true_only, rest, negate, transform
 
 if os.sys.version_info.major > 2 or (os.sys.version_info.major == 2 and os.sys.version_info.minor < 7):
-    basestring = str
+    str = str
 
 def is_readable(store):
     def fn(info):
@@ -125,8 +125,8 @@ def diff_changes(object_store, changes, diff_func=object_diff, filter_binary=Tru
     """Return a dict of diffs for the changes
     """
     pairs = changes_to_pairs(changes)
-    readable_pairs = filter(is_readable_change(object_store), pairs)
-    unreadable_pairs = filter(is_unreadable_change(object_store), pairs)
+    readable_pairs = list(filter(is_readable_change(object_store), pairs))
+    unreadable_pairs = list(filter(is_unreadable_change(object_store), pairs))
 
     for x in _diff_pairs(object_store, readable_pairs, diff_func):
         yield x
@@ -175,8 +175,8 @@ def diff_changes_paths(object_store, basepath, changes, filter_binary=True):
        in the working directory
     """
     pairs = changes_to_pairs(changes)
-    readable_pairs = filter(is_readable_change(object_store), pairs)
-    unreadable_pairs = filter(is_unreadable_change(object_store), pairs)
+    readable_pairs = list(filter(is_readable_change(object_store), pairs))
+    unreadable_pairs = list(filter(is_unreadable_change(object_store), pairs))
 
     blobs = changes_to_blobs(object_store, basepath, readable_pairs)
 
@@ -221,7 +221,7 @@ def prune_tree(tree, paths):
 
 
 def is_sha(sha):
-    return isinstance(sha, basestring) and len(sha) == 40
+    return isinstance(sha, str) and len(sha) == 40
 
 
 def blob_from_path(basepath, path):
@@ -245,12 +245,12 @@ def subrefs(refs_dict, base):
     """Return the contents of this container as a dictionary.
     """
     base = base or ''
-    keys = refs_dict.keys()
-    subkeys = map(
+    keys = list(refs_dict.keys())
+    subkeys = list(map(
         partial(subkey, base),
         keys
-    )
-    key_pairs = zip(keys, subkeys)
+    ))
+    key_pairs = list(zip(keys, subkeys))
 
     return {
         newkey: refs_dict[oldkey]
@@ -262,6 +262,6 @@ def subrefs(refs_dict, base):
 def clean_refs(refs):
     return {
         ref: sha
-        for ref, sha in refs.items()
+        for ref, sha in list(refs.items())
         if not ref.endswith('^{}')
     }

--- a/gittle/utils/paths.py
+++ b/gittle/utils/paths.py
@@ -23,7 +23,7 @@ def path_filter_file(path, abspath):
 
 @arglist
 def path_filter_regex(regexes):
-    compiled_regexes = map(re.compile, regexes)
+    compiled_regexes = list(map(re.compile, regexes))
 
     def _filter(path, abspath):
         return any([
@@ -45,7 +45,7 @@ def combine_filters(filters):
 
 
 def abspaths_only(paths_couple):
-    return map(lambda x: x[1], paths_couple)
+    return [x[1] for x in paths_couple]
 
 
 def clean_relative_paths(paths):
@@ -69,10 +69,10 @@ def dir_subpaths(root_path):
             os.path.relpath(abs_dirname, root_path)
             for abs_dirname in abs_dirnames
         ]
-        paths.extend(zip(
+        paths.extend(list(zip(
             rel_dirnames,
             abs_dirnames,
-        ))
+        )))
 
         abs_filenames = [
             os.path.join(dirname, filename)
@@ -82,10 +82,10 @@ def dir_subpaths(root_path):
             os.path.relpath(abs_filename, root_path)
             for abs_filename in abs_filenames
         ]
-        paths.extend(zip(
+        paths.extend(list(zip(
             rel_filenames,
             abs_filenames,
-        ))
+        )))
 
     return paths
 
@@ -104,11 +104,11 @@ def subpaths(root_path, filters=None):
     paths = dir_subpaths(root_path)
 
     # Do filtering
-    filtered_paths = filter(filter_func, paths)
-    relative_filtered_paths = map(first, filtered_paths)
+    filtered_paths = list(filter(filter_func, paths))
+    relative_filtered_paths = list(map(first, filtered_paths))
     return clean_relative_paths(relative_filtered_paths)
 
 
 @arglist
 def globers_to_regex(globers):
-    return map(fnmatch.translate, globers)
+    return list(map(fnmatch.translate, globers))

--- a/gittle/utils/urls.py
+++ b/gittle/utils/urls.py
@@ -8,7 +8,7 @@
 try:
     from urllib.parse import urlparse
 except ImportError:
-    from urlparse import urlparse
+    from urllib.parse import urlparse
 
 # Local imports
 from funky import first_true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -40,10 +40,10 @@ setup_kwargs = {
     'packages': ['gittle', 'gittle.utils'],
     'install_requires': [
     # PyPI
-    'paramiko==1.10.0',
+    'paramiko>=1.10.0',
     'pycrypto==2.6',
-    'dulwich==0.9.7',
-    'funky==0.0.2',
+    'dulwich>=0.9.7',
+    'funky>=0.0.2',
     ],
 }
 


### PR DESCRIPTION
The start of moving Gittle over to Python 3+

A few caveats here: I just updated setup.py requirements and ran 2to3 over the project. This means that it will break 2.7 compat. Using this pull request diff as a guide, one ought to step through the files and to the laborious work of try/except blocks for 2/3 differences.

I'll try to get to it soon, but no promises.